### PR TITLE
fixed checkbox 'checked' property

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -67,7 +67,7 @@
 			OCP.AppConfig.setValue(
 				'quota_warning',
 				$el.attr('id').substring(14),
-				$el.attr('checked') ? 'yes' : 'no',
+				$el.prop('checked') ? 'yes' : 'no',
 				{
 					success: function() {
 						OC.msg.finishedSuccess('#quota_warning_feedback', t('quota_warning', 'Saved!'));


### PR DESCRIPTION
fixed checkbox change retrieval with correct method .prop
fix #65

https://api.jquery.com/attr/

> As of jQuery 1.6, the .attr() method returns undefined for attributes that have not been set. To retrieve and change DOM properties such as the checked, selected, or disabled state of form elements, use the .prop() method.