### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 In addition an email can be sent to the users. The three percentages can be changed in the admin settings.
 It is also possible to have a link in the email and the notification for upsell options.</description>
 	<version>1.25.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Joas Schilling</author>
 	<namespace>QuotaWarning</namespace>
 	<types>

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"name": "nextcloud/quota_warning",
 	"description": "quota_warning",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"config": {
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
