### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -5,12 +5,12 @@ e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
 43fd0c5fb704cabc5f11cdfaf513236d lint-info-xml.yml
 4b40dd0073e16f74dd04e6d49dcc043d lint-php-cs.yml
 cfb31e47b6e9ab65e76c89b028754a4e lint-php.yml
-8fab08ac7da700ee304af0bf3c18b3a3 phpunit-mysql.yml
-bbe9834ddb89207caf5e19d79ebb3672 phpunit-oci.yml
-256bf1dead4ef8479e9ce7433f871548 phpunit-pgsql.yml
-4ca2c2c4b1a73182667bab908e57c185 phpunit-sqlite.yml
+6d20bb9054bf13310aaa1bf98025b3d9 phpunit-mysql.yml
+a9366230d0b876662fb0ab124ba586af phpunit-oci.yml
+33e50146debe0922d4e176f22d949aa1 phpunit-pgsql.yml
+869cf6703da576578e5d1774aa87d837 phpunit-sqlite.yml
 43878db2acac51746332618c9f731553 psalm-matrix.yml
 2dbec18233063b42f4d8e03bbb43671c reuse.yml
-94c65e30a77686c079c6dfa54a008440 sync-workflow-templates.yml
+b47a9fe981a7435caea92db33f5ad121 sync-workflow-templates.yml
 a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
 7cc949cd51ea5d604986bbdcb75c95c7 update-nextcloud-ocp-matrix.yml

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -44,7 +44,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
+          - 'stable35'
           - 'stable34'
           - 'stable33'
           - 'stable32'


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
- 🆙 Updated [phpunit-oci.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-oci.yml)
- 🆙 Updated [phpunit-pgsql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-pgsql.yml)
- 🆙 Updated [phpunit-sqlite.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-sqlite.yml)
- 🆙 Updated [sync-workflow-templates.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/sync-workflow-templates.yml)